### PR TITLE
docs: add throttled-py Python GCRA rate limiting library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,17 @@ This page tracks various projects that are based on
 * [redis-gcra][redis-gcra]: An implementation that runs in
   Lua from within Redis and which provides a Ruby API.
 
+## Python
+
+* [throttled-py][throttled-py]: An implementation that provides
+  Redis and In-Memory(Thread-Safety) storage backends, supports
+  immediate / wait-retry modes and both function and decorator
+  based usage.
+
 
 [gcra]: https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm
 [gcra-ruby]: https://github.com/Barzahlen/gcra-ruby
 [redis-cell]: https://github.com/brandur/redis-cell
 [redis-gcra]: https://github.com/rwz/redis-gcra
 [throttled]: https://github.com/throttled/throttled
+[throttled-py]: https://github.com/ZhuoZhuoCrayon/throttled-py


### PR DESCRIPTION
Hi @brandur,

I implemented [throttled-py](https://github.com/ZhuoZhuoCrayon/throttled-py) (a Python library that supports using GCRA as a rate-limiting algorithm) based on your seminal article [Rate Limiting, Cells, and GCRA](https://brandur.org/rate-limiting). This implementation includes:

1. GCRA algorithm with Redis and In-Memory storge backends
2. Detailed metrics (`remaining`, `retryAfter` & `resetAfter`) 
3. Supports immediate response and wait-retry modes, and provides function call and decorator modes.

Quick example:

```shell
$ pip install throttled-py==1.0.3
```

```python
from throttled import RateLimiterType, Throttled, rate_limter, utils

throttle = Throttled(
    # use GCRA
    using=RateLimiterType.GCRA.value,
    quota=rate_limter.per_sec(1_000, burst=1_000),
    timeout=1,
)

def call_api() -> bool:
    result = throttle.limit("/ping", cost=1)
    return result.limited

if __name__ == "__main__":
    # 👇 The actual QPS is close to the preset quota (1_000 req/s):
    # ✅ Total: 10000, 🕒 Latency: 14.7883 ms/op, 🚀 Throughput: 1078 req/s (--)
    # ❌ Denied: 54 requests
    benchmark: utils.Benchmark = utils.Benchmark()
    denied_num: int = sum(benchmark.concurrent(call_api, 10_000, workers=16))
    print(f"❌ Denied: {denied_num} requests")
```